### PR TITLE
added X-Socrata-RequestId header field to be optionally sent with Producer API requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.socrata</groupId>
   <artifactId>soda-api-java</artifactId>
   <packaging>jar</packaging>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.8.1-SNAPSHOT</version>
 
   <name>Soda2 API Client</name>
   <description>A library for accessing SODA 2 endpoints.</description>

--- a/src/main/java/com/socrata/api/HttpLowLevel.java
+++ b/src/main/java/com/socrata/api/HttpLowLevel.java
@@ -65,6 +65,7 @@ public final class HttpLowLevel
 
     public static final String SODA_VERSION = "$$version";
     public static final String SOCRATA_TOKEN_HEADER = "X-App-Token";
+    public static final String SOCRATA_REQUEST_ID_HEADER = "X-Socrata-RequestId";
     public static final String AUTH_REQUIRED_CODE = "authentication_required";
     public static final String UNEXPECTED_ERROR = "uexpectedError";
     public static final String MALFORMED_RESPONSE = "malformedResponse";
@@ -152,12 +153,15 @@ public final class HttpLowLevel
      * @param token the App Token to use for authorization and usage tracking.  If this is {@code null}, no value will be sent.
      * @return HttpLowLevel object that is completely configured to use.
      */
-    public static final HttpLowLevel instantiateBasic(@Nonnull final String url, @Nonnull final String userName, @Nonnull final String password, @Nullable final String token)
+    public static final HttpLowLevel instantiateBasic(@Nonnull final String url, @Nonnull final String userName, @Nonnull final String password, @Nullable final String token, @Nullable final String requestId)
     {
         final Client client = createClient();
         client.addFilter(new HTTPBasicAuthFilter(userName, password));
         if (token != null) {
             client.addFilter(new SodaTokenFilter(token));
+        }
+        if (requestId != null) {
+            client.addFilter(new SodaRequestIdFilter(requestId));
         }
         client.setChunkedEncodingSize(10240); // enable streaming and not put whole inputstream in memory
         //client.setConnectTimeout(1000 * 60);

--- a/src/main/java/com/socrata/api/Soda2Consumer.java
+++ b/src/main/java/com/socrata/api/Soda2Consumer.java
@@ -43,7 +43,7 @@ public class Soda2Consumer extends Soda2Base
      */
     public static final Soda2Consumer newConsumer(final String url, String userName, String password, String token)
     {
-        return new Soda2Consumer(HttpLowLevel.instantiateBasic(url, userName, password, token));
+        return new Soda2Consumer(HttpLowLevel.instantiateBasic(url, userName, password, token, null));
     }
 
     /**

--- a/src/main/java/com/socrata/api/Soda2Producer.java
+++ b/src/main/java/com/socrata/api/Soda2Producer.java
@@ -46,7 +46,25 @@ public class Soda2Producer extends Soda2Consumer
      */
     public static final Soda2Producer newProducer(final String url, String userName, String password, String token)
     {
-        return new Soda2Producer(HttpLowLevel.instantiateBasic(url, userName, password, token));
+        return new Soda2Producer(HttpLowLevel.instantiateBasic(url, userName, password, token, null));
+    }
+
+    /**
+     * Create a new Soda2Producer object, using the supplied credentials for authentication
+     * as well as a 32 character request ID to include in the header when performing publish
+     * operations (used for tracking).
+     *
+     * @param url the base URL for the SODA2 domain to access.
+     * @param userName user name to log in as
+     * @param password password to log in with
+     * @param token the App Token to use for authorization and usage tracking.  If this is {@code null}, no value will be sent.
+     * @param requestId a 32 character id unique to a single SODA 2 publish operation.  If this is {@code null}, no value will be sent.
+     *
+     * @return fully configured Soda2Producer
+     */
+    public static final Soda2Producer newProducerWithRequestId(final String url, String userName, String password, String token, String requestId)
+    {
+        return new Soda2Producer(HttpLowLevel.instantiateBasic(url, userName, password, token, requestId));
     }
 
 

--- a/src/main/java/com/socrata/api/SodaDdl.java
+++ b/src/main/java/com/socrata/api/SodaDdl.java
@@ -45,7 +45,7 @@ public class SodaDdl extends SodaWorkflow
      */
     public static final SodaDdl newDdl(final String url, String userName, String password, String token)
     {
-        return new SodaDdl(HttpLowLevel.instantiateBasic(url, userName, password, token));
+        return new SodaDdl(HttpLowLevel.instantiateBasic(url, userName, password, token, null));
     }
 
     /**

--- a/src/main/java/com/socrata/api/SodaImporter.java
+++ b/src/main/java/com/socrata/api/SodaImporter.java
@@ -51,7 +51,7 @@ public class SodaImporter extends SodaDdl
      */
     public static final SodaImporter newImporter(final String url, String userName, String password, String token)
     {
-        return new SodaImporter(HttpLowLevel.instantiateBasic(url, userName, password, token));
+        return new SodaImporter(HttpLowLevel.instantiateBasic(url, userName, password, token, null));
     }
 
     /**

--- a/src/main/java/com/socrata/api/SodaRequestIdFilter.java
+++ b/src/main/java/com/socrata/api/SodaRequestIdFilter.java
@@ -1,0 +1,35 @@
+package com.socrata.api;
+
+import com.google.common.base.Preconditions;
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.filter.ClientFilter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A client filter for Jersey that will add the SODA2 request ID to the responses.
+ */
+public class SodaRequestIdFilter extends ClientFilter {
+    private final String requestId;
+
+    /**
+     * Constructor that sets the token to add to the requests.
+     * @param requestId a 32 character id unique to a single SODA 2 publish operation.
+     */
+    public SodaRequestIdFilter(@Nonnull String requestId)
+    {
+        Preconditions.checkNotNull(requestId, "Requires a Non-Null request id");
+        this.requestId = requestId;
+    }
+
+    @Override
+    public ClientResponse handle(ClientRequest cr) throws ClientHandlerException
+    {
+        if (!cr.getMetadata().containsKey(HttpLowLevel.SOCRATA_REQUEST_ID_HEADER)) {
+            cr.getMetadata().add(HttpLowLevel.SOCRATA_REQUEST_ID_HEADER, requestId);
+        }
+        return getNext().handle(cr);
+    }
+}

--- a/src/main/java/com/socrata/api/SodaWorkflow.java
+++ b/src/main/java/com/socrata/api/SodaWorkflow.java
@@ -48,7 +48,7 @@ public class SodaWorkflow
      */
     public static final SodaWorkflow newWorkflow(final String url, String userName, String password, String token)
     {
-        return new SodaWorkflow(HttpLowLevel.instantiateBasic(url, userName, password, token));
+        return new SodaWorkflow(HttpLowLevel.instantiateBasic(url, userName, password, token, null));
     }
 
     /**

--- a/src/test/java/com/socrata/TestBase.java
+++ b/src/test/java/com/socrata/TestBase.java
@@ -74,7 +74,8 @@ public class TestBase
         final HttpLowLevel httpLowLevel = HttpLowLevel.instantiateBasic(url == null ? testProperties.getProperty(URL_PROP) : url,
                                                                         testProperties.getProperty(USER_NAME_PROP),
                                                                         testProperties.getProperty(PASSWORD_PROP),
-                                                                        testProperties.getProperty(API_KEY_PROP));
+                                                                        testProperties.getProperty(API_KEY_PROP),
+                                                                        null);
         return httpLowLevel;
     }
 


### PR DESCRIPTION
This was added to make DataSync update operations more trackable.
