### PR TITLE
BUG: Make AttachmentModel ignore unknown fields

### DIFF
--- a/src/main/java/com/socrata/model/importer/Attachment.java
+++ b/src/main/java/com/socrata/model/importer/Attachment.java
@@ -2,6 +2,7 @@ package com.socrata.model.importer;
 
 /**
  * */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class Attachment
 {
     private String blobId;


### PR DESCRIPTION
I think this could fix the issue with jackson parsing.

To be reviewed by Adrian.