### PR TITLE
Fixed some leaked references to mutable lists

### DIFF
--- a/src/main/java/com/socrata/builders/DatasetBuilder.java
+++ b/src/main/java/com/socrata/builders/DatasetBuilder.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class DatasetBuilder extends AbstractDatasetInfoBuilder<DatasetBuilder, Dataset>
 {
 
-    private List<Column>        columns = new ArrayList<Column>();
+    private final List<Column>  columns = new ArrayList<Column>();
 
     public DatasetBuilder()
     {
@@ -29,61 +29,49 @@ public class DatasetBuilder extends AbstractDatasetInfoBuilder<DatasetBuilder, D
             List<Column>  translatedColumns = Lists.newArrayList(Collections2.transform(columns, Column.COPY));
             setColumns(translatedColumns);
         }
-
     }
 
     public DatasetBuilder setColumns(List<Column> columns)
     {
-        this.columns = columns;
+        this.columns.clear();
+        this.columns.addAll(columns);
         return this;
     }
 
     public DatasetBuilder addColumn(Column column)
     {
-        if (columns == null) {
-            columns = Lists.newArrayList();
-        }
         columns.add(column);
         return this;
     }
 
     public DatasetBuilder removeColumn(String columnName)
     {
-        if (columns != null) {
-
-            for (Column column : columns) {
-                if (columnName.equals(column.getName())) {
-                    columns.remove(column);
-                    break;
-                }
+        for (Column column : columns) {
+            if (columnName.equals(column.getName())) {
+                columns.remove(column);
+                break;
             }
         }
-
         return this;
     }
 
     public DatasetBuilder updateColumn(String columnName, Column columnToUpdateTo)
     {
-        if (columns != null) {
-
-            int i=0;
-            for (Column column : columns) {
-                if (columnName.equals(column.getName())) {
-                    columns.set(i, columnToUpdateTo);
-                    break;
-                }
-                i++;
+        int i=0;
+        for (Column column : columns) {
+            if (columnName.equals(column.getName())) {
+                columns.set(i, columnToUpdateTo);
+                break;
             }
+            i++;
         }
-
         return this;
     }
 
     public Dataset build() {
         final Dataset retVal = new Dataset();
         populate(retVal);
-        retVal.setColumns(columns);
+        retVal.setColumns(new ArrayList<Column>(columns));
         return retVal;
     }
-
 }

--- a/src/main/java/com/socrata/model/importer/Dataset.java
+++ b/src/main/java/com/socrata/model/importer/Dataset.java
@@ -19,8 +19,8 @@ public class Dataset extends DatasetInfo
     public static final GenericType<List<Dataset>> LIST_TYPE = new GenericType<List<Dataset>>() {};
 
     private Integer rowIdentifierColumnId;
-    private List<String> flags = new ArrayList<String>();
-    private List<Column> columns = new ArrayList<Column>();
+    private final List<String> flags = new ArrayList<String>();
+    private final List<Column> columns = new ArrayList<Column>();
 
 
     public Dataset()
@@ -34,7 +34,7 @@ public class Dataset extends DatasetInfo
      */
     public List<Column> getColumns()
     {
-        return columns;
+        return new ArrayList<Column>(columns);
     }
 
     /**
@@ -43,7 +43,8 @@ public class Dataset extends DatasetInfo
      */
     public void setColumns(final List<Column> columns)
     {
-        this.columns = columns;
+        this.columns.clear();
+        this.columns.addAll(columns);
     }
 
     /**
@@ -53,7 +54,7 @@ public class Dataset extends DatasetInfo
      */
     public List<String> getFlags()
     {
-        return flags;
+        return new ArrayList<String>(flags);
     }
 
     /**
@@ -64,9 +65,9 @@ public class Dataset extends DatasetInfo
      */
     public void setFlags(List<String> flags)
     {
-        this.flags = flags;
+        this.flags.clear();
+        this.flags.addAll(flags);
     }
-
 
     /**
      * Looks up a column by it's name and uses that to setup the row identifier column.
@@ -76,14 +77,14 @@ public class Dataset extends DatasetInfo
     public void setupRowIdentifierColumnByName(final String columnName) {
 
         if (columnName != null) {
-            for (Column column : getColumns()) {
+            for (Column column : columns) {
                 if (columnName.equals(column.getName())) {
                     setupRowIdentifierColumn(column);
                     return;
                 }
             }
 
-            final String columnNames = StringUtils.join(Collections2.transform(getColumns(), Column.TO_NAME), ",");
+            final String columnNames = StringUtils.join(Collections2.transform(columns, Column.TO_NAME), ",");
             throw new IllegalArgumentException("No column named " + columnName + " exists for this dataset.  " +
                                                        "Current column names are: " + columnNames);
 
@@ -139,7 +140,7 @@ public class Dataset extends DatasetInfo
      */
     public Column lookupRowIdentifierColumn() {
         if (getRowIdentifierColumnId() != null) {
-            for (Column curr : getColumns()) {
+            for (Column curr : columns) {
                 if (getRowIdentifierColumnId().equals(curr.getId())) {
                     return curr;
                 }
@@ -159,6 +160,4 @@ public class Dataset extends DatasetInfo
     {
         this.rowIdentifierColumnId = rowIdentifierColumnId;
     }
-
-
 }


### PR DESCRIPTION
This seems to occur in a lot of different places and it can introduce subtle bugs
that are hard to track down.  Here's a couple examples of what you should do to
prevent reference leaks and unintentional modification of object internals.

Sorry this is a small patch.  These were the first files I looked at and it annoyed me, so I fixed it.  Then I noticed it seemed pretty pervasive in at least the importer code and I realized fixing the entire problem was going to take more time and become tedious.  And some of the changes are a little more complicated in order to maintain backwards compatibility.  For example, Column.getFlags can return null, so I'd have to check if the list is empty and return null if it is in case users are expecting that behavior when no flags have been set (which is still technically different - a user could have set it to an empty list).  And if you decide you don't care, then it's wasted effort.  But it would be good to have at least an example or two of this idiom in your codebase.  If you accept it, then I'll spend some time on the others.

Cheers,
Nathan