### PR TITLE
Allow an API user to explicitly target the OBE

### DIFF
--- a/src/main/java/com/socrata/api/DatasetDestination.java
+++ b/src/main/java/com/socrata/api/DatasetDestination.java
@@ -1,0 +1,5 @@
+package com.socrata.api;
+
+public enum DatasetDestination {
+    OBE, NBE;
+}

--- a/src/main/java/com/socrata/api/HttpLowLevel.java
+++ b/src/main/java/com/socrata/api/HttpLowLevel.java
@@ -490,13 +490,24 @@ public final class HttpLowLevel
     /**
      * If true adds ?nbe=true flag to all URIs (to enable creating datasets on New Backend)
      *
-     * @param useNbe iff true use New Backend, otherwise use old
+     * Prefer to use the setDatasetDestination method, as this one has surprising behavior
+     * when its parameter is false.
+     *
+     * @param useNbe if true use New Backend, otherwise use the default
      */
     public void setUseNewBackend(boolean useNbe) {
-        if(useNbe)
-            additionalParams.put(NBE_FLAG, "true");
-        else
-            additionalParams.remove(NBE_FLAG);
+        if(useNbe) setDatasetDestination(DatasetDestination.NBE);
+        else setDatasetDestination(null);
+    }
+
+    /**
+     * Specify (or reset to the default) the backend on which datasets will be created.
+     *
+     * @param destination The target backend, or null for the default.
+     */
+    public void setDatasetDestination(DatasetDestination destination) {
+        if(destination == null) additionalParams.remove(NBE_FLAG);
+        else additionalParams.put(NBE_FLAG, Boolean.toString(destination == DatasetDestination.NBE));
     }
 
     private Object encodeContents(final ContentEncoding contentEncoding,

--- a/src/main/java/com/socrata/api/SodaDdl.java
+++ b/src/main/java/com/socrata/api/SodaDdl.java
@@ -3,6 +3,7 @@ package com.socrata.api;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Preconditions;
+import com.socrata.api.DatasetDestination;
 import com.socrata.exceptions.LongRunningQueryException;
 import com.socrata.exceptions.SodaError;
 import com.socrata.model.SearchResults;
@@ -135,19 +136,38 @@ public class SodaDdl extends SodaWorkflow
      *
      * The new dataset will be unpublished.
      *
+     * Prefer to use the createDataset(DatasetInfo, DatasetDestination) method, as this
+     * one has surprising behavior when useNewBackend is false.
+     *
      * @param dataset dataset to create the new dataset on.  The ID should NOT be set.
-     * @param useNewBackend iff true create dataset on the New Backend
+     * @param useNewBackend if true create dataset on the New Backend, otherwise use the default.
      * @return the created dataset, the ID will be set on this.
      * @throws SodaError
      * @throws InterruptedException
      */
     public DatasetInfo createDataset(final DatasetInfo dataset, final boolean useNewBackend) throws SodaError, InterruptedException
     {
+        return createDataset(dataset, useNewBackend ? DatasetDestination.NBE : null);
+    }
+
+    /**
+     * Creates an empty dataset, based on the dataset passed in.
+     *
+     * The new dataset will be unpublished.
+     *
+     * @param dataset dataset to create the new dataset on.  The ID should NOT be set.
+     * @param destination Specify the backend for the new dataset, or null for the default.
+     * @return the created dataset, the ID will be set on this.
+     * @throws SodaError
+     * @throws InterruptedException
+     */
+    public DatasetInfo createDataset(final DatasetInfo dataset, final DatasetDestination destination) throws SodaError, InterruptedException
+    {
         SodaRequest requester = new SodaRequest<DatasetInfo>(null, dataset)
         {
             public Response issueRequest() throws LongRunningQueryException, SodaError
             {
-                httpLowLevel.setUseNewBackend(useNewBackend);
+                httpLowLevel.setDatasetDestination(destination);
                 return httpLowLevel.postRaw(viewUri, HttpLowLevel.JSON_TYPE, ContentEncoding.IDENTITY, payload);
             }
         };


### PR DESCRIPTION
This code predates core looking at the feature flag to decide where
to put a dataset when it's not specified, so it assumes that "don't
ask for a backend" implies "put it in the OBE".  That's not true
anymore.  This change keeps the existing semantics unchanged, but
adds a new way to specify the backend (and reimplements the existing
codepath in terms of it).