### PR TITLE
EN-50041: Allow user to config jersey.config.client.readTimeout

### DIFF
--- a/src/main/java/com/socrata/api/HttpLowLevel.java
+++ b/src/main/java/com/socrata/api/HttpLowLevel.java
@@ -197,8 +197,14 @@ public final class HttpLowLevel
             client.register(new SodaRequestIdFilter(requestId));
         }
         client.register(new UserAgentFilter());
+        Integer readTimeout;
+        try {
+            readTimeout = Integer.parseInt(System.getenv(ClientProperties.READ_TIMEOUT));
+        } catch (NumberFormatException ex) {
+            readTimeout = 6000000;
+        }
         client.property(ClientProperties.CONNECT_TIMEOUT, 1000);
-        client.property(ClientProperties.READ_TIMEOUT, 6000000);
+        client.property(ClientProperties.READ_TIMEOUT, readTimeout);
         return client;
     }
 


### PR DESCRIPTION
It is common that upserts take more than 2 hours.