### PR TITLE
More upsert deserialization control

### DIFF
--- a/src/main/java/com/socrata/api/StandardResultAccumulator.java
+++ b/src/main/java/com/socrata/api/StandardResultAccumulator.java
@@ -1,0 +1,60 @@
+package com.socrata.api;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+
+import com.socrata.model.UpsertError;
+import com.socrata.model.UpsertResult;
+
+public class StandardResultAccumulator implements UpsertResultAccumulator<UpsertResult> {
+    private int count = 0;
+    private long inserts = 0;
+    private long updates = 0;
+    private long deletes = 0;
+    private final List<UpsertError> errors = new LinkedList<UpsertError>();
+
+    final Long truthDataVersion;
+    final Long truthDataShapeVersion;
+
+    private StandardResultAccumulator(Long truthDataVersion, Long truthDataShapeVersion) {
+        this.truthDataVersion = truthDataVersion;
+        this.truthDataShapeVersion = truthDataShapeVersion;
+    }
+
+    public void insert(Soda2Producer.NewUpsertRow row) {
+        inserts += 1;
+        count += 1;
+    }
+    public void update(Soda2Producer.NewUpsertRow row) {
+        updates += 1;
+        count += 1;
+    }
+
+    public void delete(Soda2Producer.NewUpsertRow row) {
+        deletes += 1;
+        count += 1;
+    }
+
+    public void error(Soda2Producer.NewUpsertRow row) {
+        errors.add(new UpsertError(row.err, count, row.id));
+        count += 1;
+    }
+
+    public UpsertResult result() {
+        return new UpsertResult(inserts, updates, deletes, errors.size() > 0 ? errors : null, truthDataVersion, truthDataShapeVersion);
+    }
+
+    public UpsertResult deserializeSimple(JsonParser parser) throws IOException {
+        return parser.readValueAs(UpsertResult.class);
+    }
+
+    public static final UpsertResultAccumulatorFactory<UpsertResult> FACTORY =
+        new UpsertResultAccumulatorFactory<UpsertResult>() {
+            public UpsertResultAccumulator<UpsertResult> createAccumulator(Long truthDataVersion, long truthDataShapeVersion) {
+                return new StandardResultAccumulator(truthDataVersion, truthDataShapeVersion);
+            }
+        };
+}

--- a/src/main/java/com/socrata/api/UpsertResultAccumulator.java
+++ b/src/main/java/com/socrata/api/UpsertResultAccumulator.java
@@ -1,0 +1,16 @@
+package com.socrata.api;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+
+public interface UpsertResultAccumulator<Result> {
+    void insert(Soda2Producer.NewUpsertRow row);
+    void update(Soda2Producer.NewUpsertRow row);
+    void delete(Soda2Producer.NewUpsertRow row);
+    void error(Soda2Producer.NewUpsertRow row);
+
+    Result deserializeSimple(JsonParser parser) throws IOException;
+
+    Result result();
+}

--- a/src/main/java/com/socrata/api/UpsertResultAccumulatorFactory.java
+++ b/src/main/java/com/socrata/api/UpsertResultAccumulatorFactory.java
@@ -1,0 +1,5 @@
+package com.socrata.api;
+
+public interface UpsertResultAccumulatorFactory<Result> {
+    public UpsertResultAccumulator<Result> createAccumulator(Long truthDataVersion, long truthDataShapeVersion);
+}

--- a/src/test/java/com/socrata/api/Soda2ProducerTest.java
+++ b/src/test/java/com/socrata/api/Soda2ProducerTest.java
@@ -202,13 +202,13 @@ public class Soda2ProducerTest extends TestBase
     {
         final Soda2Producer producer = new Soda2Producer(connect());
 
-        UpsertResult noErrors = producer.deserializeUpsertResult(new ByteArrayInputStream(UPSERT_RESULT_NO_ERRORS.getBytes("utf-8")), 4L, 3L);
+        UpsertResult noErrors = producer.deserializeUpsertResult(new ByteArrayInputStream(UPSERT_RESULT_NO_ERRORS.getBytes("utf-8")), StandardResultAccumulator.FACTORY.createAccumulator(4L, 3L));
         TestCase.assertEquals(0, noErrors.errorCount());
         TestCase.assertEquals(1, noErrors.getRowsCreated());
         TestCase.assertEquals(2, noErrors.getRowsUpdated());
         TestCase.assertEquals(3, noErrors.getRowsDeleted());
 
-        UpsertResult errors1 = producer.deserializeUpsertResult(new ByteArrayInputStream(UPSERT_RESULT_1.getBytes("utf-8")), 4L, 3L);
+        UpsertResult errors1 = producer.deserializeUpsertResult(new ByteArrayInputStream(UPSERT_RESULT_1.getBytes("utf-8")), StandardResultAccumulator.FACTORY.createAccumulator(4L, 3L));
         TestCase.assertEquals(1, errors1.errorCount());
         TestCase.assertEquals(1, errors1.getErrors().get(0).getIndex());
         TestCase.assertEquals("Error1", errors1.getErrors().get(0).getError());
@@ -217,7 +217,7 @@ public class Soda2ProducerTest extends TestBase
         TestCase.assertEquals(2, errors1.getRowsUpdated());
         TestCase.assertEquals(3, errors1.getRowsDeleted());
 
-        UpsertResult errors2 = producer.deserializeUpsertResult(new ByteArrayInputStream(UPSERT_RESULT_2.getBytes("utf-8")), 4L, 3L);
+        UpsertResult errors2 = producer.deserializeUpsertResult(new ByteArrayInputStream(UPSERT_RESULT_2.getBytes("utf-8")), StandardResultAccumulator.FACTORY.createAccumulator(4L, 3L));
         TestCase.assertEquals(2, errors2.errorCount());
         TestCase.assertEquals(1, errors2.getErrors().get(0).getIndex());
         TestCase.assertEquals("Error1", errors2.getErrors().get(0).getError());
@@ -240,13 +240,13 @@ public class Soda2ProducerTest extends TestBase
     {
         final Soda2Producer producer = new Soda2Producer(connect());
 
-        UpsertResult noErrors = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_NO_ERRORS.getBytes("utf-8")), 4L, 3L);
+        UpsertResult noErrors = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_NO_ERRORS.getBytes("utf-8")), StandardResultAccumulator.FACTORY.createAccumulator(4L, 3L));
         TestCase.assertEquals(0, noErrors.errorCount());
         TestCase.assertEquals(3, noErrors.getRowsCreated());
         TestCase.assertEquals(0, noErrors.getRowsUpdated());
         TestCase.assertEquals(0, noErrors.getRowsDeleted());
 
-        UpsertResult errors1 = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_1.getBytes("utf-8")), 4L, 3L);
+        UpsertResult errors1 = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_1.getBytes("utf-8")), StandardResultAccumulator.FACTORY.createAccumulator(4L, 3L));
         TestCase.assertEquals(1, errors1.errorCount());
         TestCase.assertEquals("error3", errors1.getErrors().get(0).getError());
         TestCase.assertEquals("key3", errors1.getErrors().get(0).getPrimaryKey().textValue());
@@ -254,7 +254,7 @@ public class Soda2ProducerTest extends TestBase
         TestCase.assertEquals(2, errors1.getRowsUpdated());
         TestCase.assertEquals(0, errors1.getRowsDeleted());
 
-        UpsertResult errors2 = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_2.getBytes("utf-8")), 4L, 3L);
+        UpsertResult errors2 = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_2.getBytes("utf-8")), StandardResultAccumulator.FACTORY.createAccumulator(4L, 3L));
         TestCase.assertEquals(2, errors2.errorCount());
         TestCase.assertEquals("error2", errors2.getErrors().get(0).getError());
         TestCase.assertEquals("key2", errors2.getErrors().get(0).getPrimaryKey().textValue());
@@ -275,13 +275,13 @@ public class Soda2ProducerTest extends TestBase
     {
         final Soda2Producer producer = new Soda2Producer(connect());
 
-        UpsertResult noErrors = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_NO_ERRORS_OLD.getBytes("utf-8")), 4L, 3L);
+        UpsertResult noErrors = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_NO_ERRORS_OLD.getBytes("utf-8")), StandardResultAccumulator.FACTORY.createAccumulator(4L, 3L));
         TestCase.assertEquals(0, noErrors.errorCount());
         TestCase.assertEquals(3, noErrors.getRowsCreated());
         TestCase.assertEquals(0, noErrors.getRowsUpdated());
         TestCase.assertEquals(0, noErrors.getRowsDeleted());
 
-        UpsertResult errors1 = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_1_OLD.getBytes("utf-8")), 4L, 3L);
+        UpsertResult errors1 = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_1_OLD.getBytes("utf-8")), StandardResultAccumulator.FACTORY.createAccumulator(4L, 3L));
         TestCase.assertEquals(1, errors1.errorCount());
         TestCase.assertEquals("error3", errors1.getErrors().get(0).getError());
         TestCase.assertEquals("key3", errors1.getErrors().get(0).getPrimaryKey().textValue());
@@ -289,7 +289,7 @@ public class Soda2ProducerTest extends TestBase
         TestCase.assertEquals(2, errors1.getRowsUpdated());
         TestCase.assertEquals(0, errors1.getRowsDeleted());
 
-        UpsertResult errors2 = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_2_OLD.getBytes("utf-8")), 4L, 3L);
+        UpsertResult errors2 = producer.deserializeUpsertResult(new ByteArrayInputStream(SODA_SERVER_UPSERT_RESULT_2_OLD.getBytes("utf-8")), StandardResultAccumulator.FACTORY.createAccumulator(4L, 3L));
         TestCase.assertEquals(2, errors2.errorCount());
         TestCase.assertEquals("error2", errors2.getErrors().get(0).getError());
         TestCase.assertEquals("key2", errors2.getErrors().get(0).getPrimaryKey().textValue());


### PR DESCRIPTION
This preserves backward compatibility (such as it is), but also allows us to _not_ accumulate all the errors from soda-fountain into a list when we only care about their count.